### PR TITLE
Add cmake install directives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SOURCE_FILES
         uInput.cpp uInputSetup.cpp uInputResource.cpp
         uInput.hpp CommonIncludes.hpp uInputSetup.hpp)
 
+include(GNUInstallDirs)
+
 add_library(uInputPlus ${SOURCE_FILES})
 target_include_directories(uInputPlus PUBLIC .)
 
@@ -14,4 +16,10 @@ add_executable(uInputPlus_test test.cpp)
 target_link_libraries(uInputPlus_test uInputPlus)
 
 configure_file(uInputPlus.pc.in uInputPlus.pc @ONLY)
+
+
+install(TARGETS uInputPlus
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES uInput.hpp CommonIncludes.hpp uInputSetup.hpp
+        DESTINATION include/)
 


### PR DESCRIPTION
To make nix builds work, it expect a make install command to
be available.
Adding these directives seems to fix the build.

If it's no trouble to you, please consider adding them.